### PR TITLE
Incorporate VPP GSO fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VPP_VERSION=v22.02-rc0-164-g13f19f8e5
+ARG VPP_VERSION=v22.02-rc0-101-g005fc7448
 FROM ghcr.io/edwarnicke/govpp/vpp:${VPP_VERSION} as go
 COPY --from=golang:1.16.3-buster /usr/local/go/ /go
 ENV PATH ${PATH}:/go/bin

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1
-	github.com/edwarnicke/govpp v0.0.0-20211101202831-a045363b0c36
+	github.com/edwarnicke/govpp v0.0.0-20211126025848-29218cd40e80
 	github.com/edwarnicke/grpcfd v0.1.1
 	github.com/edwarnicke/vpphelper v0.0.0-20210617172001-3e6797de32c3
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/edwarnicke/exechelper v1.0.2 h1:dD49Ui2U0FBFxxhalnKw6vLS0P0TkgnXBRvKL/xmC5w=
 github.com/edwarnicke/exechelper v1.0.2/go.mod h1:/T271jtNX/ND4De6pa2aRy2+8sNtyCDB1A2pp4M+fUs=
 github.com/edwarnicke/govpp v0.0.0-20211023203533-76f2c92be8d5/go.mod h1:kHDnxA+SSNFeMEHz7xvhub1zvx4mOTRlWWRCay2n5NM=
-github.com/edwarnicke/govpp v0.0.0-20211101202831-a045363b0c36 h1:4SBFlaF0UD94vXw6xx2Bai47HXLDsS7tbjL2ijPXRog=
-github.com/edwarnicke/govpp v0.0.0-20211101202831-a045363b0c36/go.mod h1:kHDnxA+SSNFeMEHz7xvhub1zvx4mOTRlWWRCay2n5NM=
+github.com/edwarnicke/govpp v0.0.0-20211126025848-29218cd40e80 h1:nKFCxwLM2ABQAKrEkq4s6lYrkMJg6nSHzAqvq/D/et0=
+github.com/edwarnicke/govpp v0.0.0-20211126025848-29218cd40e80/go.mod h1:kHDnxA+SSNFeMEHz7xvhub1zvx4mOTRlWWRCay2n5NM=
 github.com/edwarnicke/grpcfd v0.1.1 h1:ej5J1V7iSRa4RF1OIXfaVKsEWCMLIGiNECLgh7juxBA=
 github.com/edwarnicke/grpcfd v0.1.1/go.mod h1:rHihB9YvNMixz8rS+ZbwosI2kj65VLkeyYAI2M+/cGA=
 github.com/edwarnicke/log v1.0.0 h1:T6uRNCmR99GTt/CpRr2Gz8eGW8fm0HMThDNGdNxPaGk=


### PR DESCRIPTION
https://github.com/edwarnicke/govpp/pull/44

af-packet may incorrectly mark a packet as being a GSO packet
due to a slight miscomputation around the MTU. This should fix that.

https://gerrit.fd.io/r/c/vpp/+/34585

Fixes networkservicemesh/sdk#1148

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
